### PR TITLE
Remove deprecated SUPPORT_WHITE_VALUE import for LightEntity

### DIFF
--- a/light.py
+++ b/light.py
@@ -52,7 +52,6 @@ from homeassistant.components.light import (
     SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT,
     SUPPORT_TRANSITION,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.const import (


### PR DESCRIPTION
Home-Assistant removed the deprecated value `SUPPORT_WHITE_VALUE` from the `LightEntity` in https://github.com/home-assistant/core/commit/426a620084c75e98804ea03266b86041819f62ed and https://github.com/home-assistant/core/commit/60c8d95a77959168c2c217a633479ccf5066cbcf in 2022.9

https://developers.home-assistant.io/blog/2022/08/18/light_white_value_removed/

The integration wouldn't load after the update to 2022.9 due to the removed export from Home-Assistant. After removing the import from `light.py` the integration loads fine again.
I didn't find any references to `SUPPORT_WHITE_VALUE` in Klyqa's code so I think it's safe to remove it?