### PR TITLE
use `async_forward_entry_setups` instead of deprecated `async_setup_platforms`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -149,8 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, unique_id=entry.data[CONF_USERNAME]
         )
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
Fixing the deprecation mentioned here: https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/  
Might close #49 and #50 - but I'm new to using this extension (and home assistant). Please advise :)