### PR TITLE
Fix Klyqa integration lamp creation issue (#55)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -55,7 +55,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 
-PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.LIGHT]
 SCAN_INTERVAL = timedelta(seconds=30)
 
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -111,9 +111,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 polling=self.polling,
                 scan_interval=self.scan_interval,
             )
-            login = self.hass.async_run_job(
-                klyqa.login,
-            )
+            login = await self.hass.async_add_executor_job(klyqa.login)
             if login:
                 await asyncio.wait_for(login, timeout=30)
             self.klyqa = klyqa
@@ -263,9 +261,7 @@ class KlyqaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 scan_interval=self.scan_interval,
             )
 
-            login = self.hass.async_run_job(
-                klyqa.login,
-            )
+            login = await self.hass.async_add_executor_job(klyqa.login)
             if login:
                 await asyncio.wait_for(login, timeout=30)
             else:

--- a/light.py
+++ b/light.py
@@ -111,7 +111,7 @@ async def async_setup_entry(
     klyqa = hass.data[DOMAIN].entries[entry.entry_id]
     if klyqa:
         await async_setup_klyqa(
-            hass, ConfigType(entry.data), async_add_entities, entry=entry, klyqa=klyqa
+            hass, entry.data, async_add_entities, entry=entry, klyqa=klyqa
         )
     return True
 
@@ -161,7 +161,7 @@ async def create_klyqa_api_from_config(hass, config: ConfigType) -> HAKlyqaAccou
         scan_interval=scan_interval,
     )
     component.klyqa_accounts[username] = klyqa
-    login = hass.async_run_job(klyqa.login)
+    login = await hass.async_add_executor_job(klyqa.login)
     try:
         if login:
             await asyncio.wait_for(login, timeout=11)


### PR DESCRIPTION
This pull request addresses the issue reported in [#55](https://github.com/klyqa/home-assistant-integration/issues/55) where the Klyqa integration was unable to create lamps in Home Assistant. The following changes have been made:

1. Updated asynchronous calls in `config_flow.py` and `light.py`:
   - Replaced `async_run_job` with `await hass.async_add_executor_job` to address deprecation warnings and improve asynchronous behavior.

2. Modified configuration handling in `light.py`:
   - Removed the `ConfigType` wrapper and now passing `entry.data` directly, fixing a type-related error.

3. Simplified platform configuration in `__init__.py`:
   - Removed the reference to the switch platform, focusing only on the light platform.
   - This change was necessary to ensure proper functionality of Klyqa groups.

These changes should resolve the integration loading issues and allow proper creation of lamp entities in Home Assistant.

Testing:
- The integration has been tested to load successfully.
- Lamp entities are now being created correctly in Home Assistant.
- No warnings related to `async_run_job` deprecation are observed in the logs.
- Klyqa groups are functioning properly after removing the switch platform reference.
- Testing was conducted with the following Klyqa lamp models:
  - G96 Vintage Lamp
  - E27 Color
  - E14 Color

Please review and test these changes to ensure they resolve the reported issue and work correctly with various Klyqa lamp models.